### PR TITLE
Add Env variables for Output template and Playlist output template

### DIFF
--- a/DownMedia/source/downmedia_functions.rb
+++ b/DownMedia/source/downmedia_functions.rb
@@ -55,6 +55,21 @@ Download_dir = get_env(
   as_pathname: true
 )
 
+# ALLOW Template override for playlist output format.  
+Playlist_out_template = get_env(
+  variable: ENV['playlist_out_template'],
+  default: '%(playlist)s/%(playlist_index)s-%(title)s.%(ext)s',
+  as_pathname: false
+)
+
+# ALLOW Template override for individual output format.  
+Out_template = get_env(
+  variable: ENV['out_template'],
+  default: '%(title)s.%(ext)s',
+  as_pathname: false
+)
+
+
 Pid_file = Pathname(ENV['alfred_workflow_cache']).join('pid.txt')
 Progress_file = Pathname(ENV['alfred_workflow_cache']).join('progress.txt')
 Query_file = Pathname(ENV['alfred_workflow_cache']).join('query.json')
@@ -200,9 +215,9 @@ def download_url(url, media_type, add_to_watchlist_string, full_playlist_string)
   full_playlist = to_bool(full_playlist_string)
   encoded_url = CGI.escape_html(url)
 
+  # Use Result of Custom Tempalates.
   title_template = full_playlist ?
-    '%(playlist)s/%(playlist_index)s-%(title)s.%(ext)s' :
-    '%(title)s.%(ext)s'
+   Playlist_out_template : Out_template
 
   # Video format is forced for consistency between --get-filename and what is downloaded
   flags = media_type == 'audio' ?

--- a/DownMedia/source/downmedia_functions.rb
+++ b/DownMedia/source/downmedia_functions.rb
@@ -55,20 +55,15 @@ Download_dir = get_env(
   as_pathname: true
 )
 
-# ALLOW Template override for playlist output format.  
-Playlist_out_template = get_env(
-  variable: ENV['playlist_out_template'],
-  default: '%(playlist)s/%(playlist_index)s-%(title)s.%(ext)s',
-  as_pathname: false
+Single_title_template = get_env(
+  variable: ENV['single_title_template'],
+  default: '%(title)s.%(ext)s'
 )
 
-# ALLOW Template override for individual output format.  
-Out_template = get_env(
-  variable: ENV['out_template'],
-  default: '%(title)s.%(ext)s',
-  as_pathname: false
+Playlist_title_template = get_env(
+  variable: ENV['playlist_title_template'],
+  default: '%(playlist)s/%(playlist_index)s-%(title)s.%(ext)s'
 )
-
 
 Pid_file = Pathname(ENV['alfred_workflow_cache']).join('pid.txt')
 Progress_file = Pathname(ENV['alfred_workflow_cache']).join('progress.txt')
@@ -214,10 +209,7 @@ def download_url(url, media_type, add_to_watchlist_string, full_playlist_string)
   add_to_watchlist = to_bool(add_to_watchlist_string)
   full_playlist = to_bool(full_playlist_string)
   encoded_url = CGI.escape_html(url)
-
-  # Use Result of Custom Tempalates.
-  title_template = full_playlist ?
-   Playlist_out_template : Out_template
+  title_template = full_playlist ? Playlist_title_template : Single_title_template
 
   # Video format is forced for consistency between --get-filename and what is downloaded
   flags = media_type == 'audio' ?


### PR DESCRIPTION
Added two Environment variable to permit the customization of the output templates, for a single file and a Playlist.

The two variables are `playlist_out_template` and `out_template`

if not found then the current defaults are used.