### PR TITLE
feat(DownMedia): add Firefox support

### DIFF
--- a/DownMedia/source/get_title_and_url.js
+++ b/DownMedia/source/get_title_and_url.js
@@ -1,17 +1,23 @@
 #!/usr/bin/osascript -l JavaScript
 
-const frontmost_app_name = Application('System Events').applicationProcesses.where({ frontmost: true }).name()[0]
-const frontmost_app = Application(frontmost_app_name)
+const frontmost_app = Application('System Events').applicationProcesses.where({ frontmost: true })
+const frontmost_app_name = frontmost_app.name()[0]
 
 const chromium_variants = ['Google Chrome', 'Chromium', 'Opera', 'Vivaldi', 'Brave Browser', 'Microsoft Edge']
 const webkit_variants = ['Safari', 'Webkit']
+const firefox_variants = ['firefox']
+
+let current_tab_title, current_tab_url;
 
 if (chromium_variants.some(app_name => frontmost_app_name.startsWith(app_name))) {
-  var current_tab_title = frontmost_app.windows[0].activeTab.name()
-  var current_tab_url = frontmost_app.windows[0].activeTab.url()
+  current_tab_title = frontmost_app.windows[0].activeTab.name()
+  current_tab_url = frontmost_app.windows[0].activeTab.url()
 } else if (webkit_variants.some(app_name => frontmost_app_name.startsWith(app_name))) {
-  var current_tab_title = frontmost_app.windows[0].currentTab.name()
-  var current_tab_url = frontmost_app.windows[0].currentTab.url()
+  current_tab_title = frontmost_app.windows[0].currentTab.name()
+  current_tab_url = frontmost_app.windows[0].currentTab.url()
+} else if (firefox_variants.some(app_name => frontmost_app_name.startsWith(app_name))) {
+  current_tab_title = frontmost_app.windows[0].title()
+  current_tab_url = frontmost_app.windows[0].groups[0].toolbars.byName('Navigation').comboBoxes[0].uiElements[0].value()
 } else {
   throw new Error('You need a supported browser as your frontmost app')
 }


### PR DESCRIPTION
# Motivation
This PR adds support for Firefox and Firefox Developer edition in the DownMedia workflow.

Since there's no longer a need to change any browser settings for these APIs to work, I think it makes sense to add support for these browsers.

I also tested this with multiple windows in those browsers.

# Screenshots

<img width="1124" alt="CleanShot 2022-12-17 at 21 50 51@2x" src="https://user-images.githubusercontent.com/551858/208280872-2607da01-d549-4339-908e-18d3e3c7be93.png">

<img width="1123" alt="CleanShot 2022-12-17 at 22 04 43@2x" src="https://user-images.githubusercontent.com/551858/208280876-28324759-ce51-4dca-8337-53ab4a50b327.png">
